### PR TITLE
Fix invalid input types in Interview component

### DIFF
--- a/src/components/Interview.tsx
+++ b/src/components/Interview.tsx
@@ -631,7 +631,9 @@ const Interview: React.FC<InterviewProps> = ({
           <CardContent>
             <p className="text-lg leading-relaxed mb-6">{currentQuestion.question}</p>
             <input
-              type={currentQuestion.type === 'text' ? 'text' : currentQuestion.type}
+              type={["text", "email", "tel", "url"].includes(currentQuestion.type)
+                ? currentQuestion.type
+                : "text"}
               value={currentResponse}
               onChange={(e) => setCurrentResponse(e.target.value)}
               placeholder="Type your answer here..."


### PR DESCRIPTION
## Summary
- ensure text input type defaults to `text` for custom fields in the interview

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6849f0dba1788332ad5ac946c8004aa5